### PR TITLE
Fixed: Allow Git special versions to be used for diff.

### DIFF
--- a/src/main/php/Arbit/VCSWrapper/GitCli/Resource.php
+++ b/src/main/php/Arbit/VCSWrapper/GitCli/Resource.php
@@ -267,10 +267,6 @@ abstract class Resource extends \Arbit\VCSWrapper\Resource implements \Arbit\VCS
      */
     public function getDiff($version, $current = null)
     {
-        if (!in_array($version, $this->getVersions(), true)) {
-            throw new \UnexpectedValueException("Invalid log entry $version for {$this->path}.");
-        }
-
         $current = ($current === null) ? $this->getVersionString() : $current;
 
         if (($diff = \Arbit\VCSWrapper\Cache\Manager::get($this->path, $version, 'diff')) === false) {

--- a/src/main/php/Arbit/VCSWrapper/GitCli/Resource.php
+++ b/src/main/php/Arbit/VCSWrapper/GitCli/Resource.php
@@ -273,7 +273,7 @@ abstract class Resource extends \Arbit\VCSWrapper\Resource implements \Arbit\VCS
             // Refetch the basic content information, and cache it.
             $process = new \Arbit\VCSWrapper\GitCli\Process();
             $process->workingDirectory($this->root);
-            $process->argument('diff')->argument('--no-ext-diff');
+            $process->argument('diff')->argument('--no-ext-diff')->argument('--');
             $process->argument($version . '..' . $current)->argument(new \SystemProcess\Argument\PathArgument('.' . $this->path))->execute();
 
             // Parse resulting unified diff

--- a/src/main/php/Arbit/VCSWrapper/GitCli/Resource.php
+++ b/src/main/php/Arbit/VCSWrapper/GitCli/Resource.php
@@ -273,7 +273,7 @@ abstract class Resource extends \Arbit\VCSWrapper\Resource implements \Arbit\VCS
             // Refetch the basic content information, and cache it.
             $process = new \Arbit\VCSWrapper\GitCli\Process();
             $process->workingDirectory($this->root);
-            $process->argument('diff')->argument('--no-ext-diff')->argument('--');
+            $process->argument('diff')->argument('--no-ext-diff');
             $process->argument($version . '..' . $current)->argument(new \SystemProcess\Argument\PathArgument('.' . $this->path))->execute();
 
             // Parse resulting unified diff


### PR DESCRIPTION
While this is not strictly in the sense of an abstraction layer, this patch allows to use Git special revision keywords (e.g. HEAD or $version^) for diffing, which is useful for some cases.
